### PR TITLE
tickets/SP-2447: various changes needed to support using sims_sv_survey code as a driver for pre-night simulations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
+    "python-envs.pythonProjects": [],
+    "editor.inlineSuggest.enabled": false
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
 ]
 
 [project.scripts]
+fetch_sv_visits = "sv_survey.simulate_sv:fetch_sv_visits_cli"
 make_sv_scheduler = "sv_survey.simulate_sv:make_sv_scheduler_cli"
 make_model_observatory = "sv_survey.simulate_sv:make_model_observatory_cli"
 make_band_scheduler = "sv_survey.simulate_sv:make_band_scheduler_cli"

--- a/sv_survey/simulate_sv.py
+++ b/sv_survey/simulate_sv.py
@@ -25,6 +25,7 @@ from rubin_scheduler.scheduler.utils import (
 from rubin_scheduler.utils import Site
 from rubin_sim.sim_archive import make_sim_archive_dir, transfer_archive_dir
 from rubin_sim.sim_archive.make_snapshot import get_scheduler_from_config
+from rubin_sim.sim_archive.prenight import AnomalousOverheadFunc
 
 from . import sv_support as svs
 
@@ -528,6 +529,13 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
     )
     parser.add_argument("--label", type=str, default="", help="The tags on the simulation.")
     parser.add_argument("--delay", type=float, default=0.0, help="Minutes after nominal to start.")
+    parser.add_argument("--anom_overhead_scale", type=float, default=0.0, help="scale of scatter in the slew")
+    parser.add_argument(
+        "--anom_overhead_seed",
+        type=int,
+        default=1,
+        help="random number seed for anomalous scatter in overhead",
+    )
     parser.add_argument("--tags", type=str, default=[], nargs="*", help="The tags on the simulation.")
     args = parser.parse_args() if len(cli_args) == 0 else parser.parse_args(cli_args)
 
@@ -555,6 +563,13 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
     capture_env = args.capture_env
     telescope = args.telescope
     delay = args.delay
+    anom_overhead_scale = args.anom_overhead_scale
+    anom_overhead_seed = args.anom_overhead_seed
+
+    if anom_overhead_scale > 0:
+        anomalous_overhead_func = AnomalousOverheadFunc(anom_overhead_seed, anom_overhead_scale)
+    else:
+        anomalous_overhead_func = None
 
     if keep_rewards:
         scheduler.keep_rewards = keep_rewards
@@ -569,7 +584,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
             initial_opsim,
             day_obs,
             sim_nights,
-            anomalous_overhead_func=None,
+            anomalous_overhead_func=anomalous_overhead_func,
             run_name=run_name,
             keep_rewards=keep_rewards,
             delay=delay,
@@ -582,7 +597,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
             survey_info,
             day_obs,
             sim_nights,
-            anomalous_overhead_func=None,
+            anomalous_overhead_func=anomalous_overhead_func,
             keep_rewards=keep_rewards,
             delay=delay,
         )

--- a/sv_survey/simulate_sv.py
+++ b/sv_survey/simulate_sv.py
@@ -41,6 +41,7 @@ __all__ = [
     "fetch_previous_sv_visits",
     "setup_sv",
     "run_sv_sim",
+    "fetch_sv_visits_cli",
     "make_sv_scheduler_cli",
     "make_model_observatory_cli",
     "make_band_scheduler_cli",
@@ -384,6 +385,27 @@ def sv_sim(
     )
 
     return visits, survey_info
+
+
+def fetch_sv_visits_cli(cli_args: list = []) -> int:
+    parser = argparse.ArgumentParser(description="Query the consdb for completed sv visits")
+    parser.add_argument("dayobs", type=int, help="Dayobs before which to query.")
+    parser.add_argument("file_name", type=str, help="Name of opsim db file to write.")
+    parser.add_argument(
+        "--site", type=str, default="usdf", help="site of consdb to query (usdf, usdf-dev, or summit)"
+    )
+    args = parser.parse_args() if len(cli_args) == 0 else parser.parse_args(cli_args)
+
+    dayobs = args.dayobs
+    file_name = args.file_name
+    site = args.site
+
+    visits = fetch_previous_sv_visits(dayobs, site=site)
+
+    with sqlite3.connect(file_name) as connection:
+        visits.to_sql("observations", connection, index=False)
+
+    return 0
 
 
 def make_sv_scheduler_cli(cli_args: list = []) -> int:

--- a/sv_survey/simulate_sv.py
+++ b/sv_survey/simulate_sv.py
@@ -411,6 +411,7 @@ def fetch_sv_visits_cli(cli_args: list = []) -> int:
     parser = argparse.ArgumentParser(description="Query the consdb for completed sv visits")
     parser.add_argument("dayobs", type=int, help="Dayobs before which to query.")
     parser.add_argument("file_name", type=str, help="Name of opsim db file to write.")
+    parser.add_argument("token_file", type=str, help="files with USDF access token")
     parser.add_argument(
         "--site", type=str, default="usdf", help="site of consdb to query (usdf, usdf-dev, or summit)"
     )
@@ -418,9 +419,10 @@ def fetch_sv_visits_cli(cli_args: list = []) -> int:
 
     dayobs = args.dayobs
     file_name = args.file_name
+    token_file = args.token_file
     site = args.site
 
-    visits = fetch_previous_sv_visits(dayobs, site=site)
+    visits = fetch_previous_sv_visits(dayobs, token_file, site=site)
 
     with sqlite3.connect(file_name) as connection:
         visits.to_sql("observations", connection, index=False)


### PR DESCRIPTION
Trying to track down why the older prenight code wasn't replicating the driver code sims_sv_survey, and thinking that keeping them in sync was probably going to be difficult anyway, I've gone ahead and made a bunch of changes needed to run pre-night simulations using as much of the same code as is in this repository as possible.

In particular, these changes include:

1. Added support for delayed start of observing
2. Added support for scatter in the overhead between exposures
3. Added a CLI for querying the consdb for completed visits using sims_sv_survey code
4. Added support for recording rewards
5. Added options to call sim_archive code to add the results to the prenight archive instead of just saving the database.