### PR TITLE
tickets/SP-2167: Replace prototype metadata tracking of opsim simulations for schedview with one based on a postgresql database

### DIFF
--- a/sv_survey/simulate_sv.py
+++ b/sv_survey/simulate_sv.py
@@ -14,7 +14,6 @@ import rubin_nights.dayobs_utils as rn_dayobs
 import rubin_nights.rubin_sim_addons as rn_sim
 from astroplan import Observer
 from astropy.time import Time, TimeDelta
-from lsst.resources import ResourcePath
 from rubin_nights import connections
 from rubin_nights.augment_visits import augment_visits
 from rubin_scheduler.scheduler import sim_runner
@@ -24,7 +23,7 @@ from rubin_scheduler.scheduler.utils import (
     SchemaConverter,
 )
 from rubin_scheduler.utils import Site
-from rubin_sim.sim_archive import make_sim_archive_dir, transfer_archive_dir
+from rubin_sim.sim_archive import make_sim_data_dir
 from rubin_sim.sim_archive.make_snapshot import get_scheduler_from_config
 from rubin_sim.sim_archive.prenight import AnomalousOverheadFunc
 
@@ -658,9 +657,6 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
     parser.add_argument("sim_nights", type=int, help="number of nights to run.")
     parser.add_argument("run_name", type=str, help="Run (also db output) name.")
     parser.add_argument("--keep_rewards", action="store_true", help="Compute rewards data.")
-    parser.add_argument(
-        "--archive", type=str, default="", help="URI of the archive in which to store the results"
-    )
     parser.add_argument("--telescope", type=str, default="simonyi", help="The telescope simulated.")
     parser.add_argument("--label", type=str, default="", help="The tags on the simulation.")
     parser.add_argument("--delay", type=float, default=0.0, help="Minutes after nominal to start.")
@@ -691,7 +687,6 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
     sim_nights = args.sim_nights
     run_name = args.run_name
     nside = observatory.nside
-    archive_uri = args.archive
     keep_rewards = args.keep_rewards
     tags = args.tags
     label = args.label
@@ -711,7 +706,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
 
     survey_info = svs.survey_times(verbose=True, no_downtime=True, nside=nside)
 
-    if len(archive_uri) == 0 and results_dir is None:
+    if results_dir is None:
         run_sv_sim(
             scheduler,
             observatory,
@@ -738,7 +733,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
         )
         LOGGER.info("Simulation complete.")
 
-        data_path = make_sim_archive_dir(
+        data_path = make_sim_data_dir(
             observations,
             rewards if keep_rewards else None,
             obs_rewards if keep_rewards else None,
@@ -749,9 +744,5 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
             data_path=results_dir,
         )
         LOGGER.info(f"Wrote results in directory: {data_path.name}")
-
-        if len(archive_uri) == 0:
-            sim_archive_uri = transfer_archive_dir(data_path.name, archive_uri)
-            LOGGER.info(f"Transferred {data_path} to {sim_archive_uri}")
 
     return 0

--- a/sv_survey/simulate_sv.py
+++ b/sv_survey/simulate_sv.py
@@ -662,11 +662,6 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
         "--archive", type=str, default="", help="URI of the archive in which to store the results"
     )
     parser.add_argument("--telescope", type=str, default="simonyi", help="The telescope simulated.")
-    parser.add_argument(
-        "--capture_env",
-        action="store_true",
-        help="Record the current environment as the simulation environment.",
-    )
     parser.add_argument("--label", type=str, default="", help="The tags on the simulation.")
     parser.add_argument("--delay", type=float, default=0.0, help="Minutes after nominal to start.")
     parser.add_argument("--anom_overhead_scale", type=float, default=0.0, help="scale of scatter in the slew")
@@ -700,7 +695,6 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
     keep_rewards = args.keep_rewards
     tags = args.tags
     label = args.label
-    capture_env = args.capture_env
     telescope = args.telescope
     delay = args.delay
     anom_overhead_scale = args.anom_overhead_scale
@@ -751,7 +745,6 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
             in_files={"scheduler": args.scheduler, "observatory": args.observatory},
             tags=tags,
             label=label,
-            capture_env=capture_env,
             opsim_metadata={"telescope": telescope},
             data_path=results_dir,
         )

--- a/sv_survey/simulate_sv.py
+++ b/sv_survey/simulate_sv.py
@@ -14,6 +14,7 @@ import rubin_nights.dayobs_utils as rn_dayobs
 import rubin_nights.rubin_sim_addons as rn_sim
 from astroplan import Observer
 from astropy.time import Time, TimeDelta
+from lsst.resources import ResourcePath
 from rubin_nights import connections
 from rubin_nights.augment_visits import augment_visits
 from rubin_scheduler.scheduler import sim_runner
@@ -676,6 +677,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
         help="random number seed for anomalous scatter in overhead",
     )
     parser.add_argument("--tags", type=str, default=[], nargs="*", help="The tags on the simulation.")
+    parser.add_argument("--results", type='str', default='', help="Results directory.")
     args = parser.parse_args() if len(cli_args) == 0 else parser.parse_args(cli_args)
 
     with open(args.scheduler, "rb") as sched_io:
@@ -703,6 +705,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
     delay = args.delay
     anom_overhead_scale = args.anom_overhead_scale
     anom_overhead_seed = args.anom_overhead_seed
+    results_dir = args.results if len(args.results)>0 else None
 
     if anom_overhead_scale > 0:
         anomalous_overhead_func = AnomalousOverheadFunc(anom_overhead_seed, anom_overhead_scale)
@@ -714,7 +717,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
 
     survey_info = svs.survey_times(verbose=True, no_downtime=True, nside=nside)
 
-    if len(archive_uri) == 0:
+    if len(archive_uri) == 0 and results_dir is None:
         run_sv_sim(
             scheduler,
             observatory,
@@ -750,10 +753,12 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
             label=label,
             capture_env=capture_env,
             opsim_metadata={"telescope": telescope},
+            data_dir=results_dir,
         )
-        LOGGER.info(f"Created simulation archived directory: {data_path.name}")
+        LOGGER.info(f"Wrote results in directory: {data_path.name}")
 
-        sim_archive_uri = transfer_archive_dir(data_path.name, archive_uri)
-        LOGGER.info(f"Transferred {data_path} to {sim_archive_uri}")
+        if len(archive_uri) == 0:
+            sim_archive_uri = transfer_archive_dir(data_path.name, archive_uri)
+            LOGGER.info(f"Transferred {data_path} to {sim_archive_uri}")
 
     return 0

--- a/sv_survey/simulate_sv.py
+++ b/sv_survey/simulate_sv.py
@@ -677,7 +677,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
         help="random number seed for anomalous scatter in overhead",
     )
     parser.add_argument("--tags", type=str, default=[], nargs="*", help="The tags on the simulation.")
-    parser.add_argument("--results", type='str', default='', help="Results directory.")
+    parser.add_argument("--results", type=str, default='', help="Results directory.")
     args = parser.parse_args() if len(cli_args) == 0 else parser.parse_args(cli_args)
 
     with open(args.scheduler, "rb") as sched_io:
@@ -753,7 +753,7 @@ def run_sv_sim_cli(cli_args: list = []) -> int:
             label=label,
             capture_env=capture_env,
             opsim_metadata={"telescope": telescope},
-            data_dir=results_dir,
+            data_path=results_dir,
         )
         LOGGER.info(f"Wrote results in directory: {data_path.name}")
 


### PR DESCRIPTION
This is one of many PRs that need to be merged at the same time. See the SP-2167 PR for rubin_sim for more details.

The change to this repo is to `have run_sv_sim_cli` just write to a local directory instead of interacting with the archive directly. The sims then get written to the archive in a separate step outside of this repo, better separating concerns.